### PR TITLE
Fix link to github repository

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule BlockingQueue.Mixfile do
      contributors: ["Joseph Kain"],
      licenses: ["MIT"],
      links: %{
-       "github" => "https://github.com/joekain/blocking_queue"
+       "github" => "https://github.com/joekain/BlockingQueue"
      }]
   end
 end


### PR DESCRIPTION
Because link on https://hex.pm/packages/blocking_queue is broken